### PR TITLE
Add C wrapper around read function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # file(GLOB_RECURSE SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 # add_library(distributed_mmio STATIC ${SRC_FILES})
 
-add_library(distributed_mmio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/src/mmio.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/mmio_utils.cpp)
+add_library(distributed_mmio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/src/mmio.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/mmio_utils.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/mmio_c_wrapper.cpp)
 target_include_directories(distributed_mmio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_executable(mtx_to_bmtx ${CMAKE_CURRENT_SOURCE_DIR}/src/mtx_to_bmtx.cpp)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
 # Distributed MMIO
 
-Lightweight Templated `C++` library for local or distributed reading of Matrix Market files.
+Lightweight Templated `C++` library for local or distributed reading of Matrix Market files. Can be also used in a `C project via a C wrapper.
 
 This repository integrates with MtxMan ([https://github.com/ThomasPasquali/MtxMan](https://github.com/ThomasPasquali/MtxMan)) to simplify the management of Matrix Market files, check it out!
 
 ## Including "Distributed MMIO" in your project
 
-Copy the repo into your project or clone it as a git submodule.
+This library can be included either as a submodule or by copying the source files directly into your project.
 
-Then simply add it to you CMake:
+### CMake Usage (for C++ projects)
+
+If you are using CMake, you can include this library as follows:
 
 ```cmake
 add_subdirectory(distributed_mmio)
 ```
 
 If you are not using CMake, make sure to include the `distributed_mmio/include` directory and `distributed_mmio/src/mmio.cpp`, `distributed_mmio/src/mmio_utils.cpp` source files.
+
+### Makefile Usage (for C projects)
+
+If you are using a Makefile, first build the library:
+
+```bash
+cd distributed_mmio
+make
+```
+Then, you can include the library in your project by adding the following lines to your Makefile:
+
+```makefile
+CFLAGS += -I/path/to/distributed_mmio/include
+LDFLAGS += /path/to/distributed_mmio/libdistributed_mmio.a
+```
 
 <!-- ## Including "Distributed MMIO" with CMake
 
@@ -41,9 +58,15 @@ target_link_libraries(my_target PRIVATE distributed_mmio)
 ```c++
 #include "../distributed_mmio/include/mmio.h"
 // ...
-CSR_local<uint32_t, float> *csr_matrix = Distr_MMIO_CSR_local_read<uint32_t, float>("path/to/mtx_file");
-COO_local<uint64_t, double> *coo_matrix = Distr_MMIO_COO_local_read<uint64_t, double>("path/to/mtx_file");
+CSR_local<uint32_t, float> *csr_matrix = Distr_MMIO_CSR_local_read<uint32_t, float>("path/to/mtx_file", false, &meta);
+COO_local<uint64_t, double> *coo_matrix = Distr_MMIO_COO_local_read<uint64_t, double>("path/to/mtx_file", false, &meta);
 ```
+
+The `Distr_MMIO_CSR_local_read` and `Distr_MMIO_COO_local_read` functions take the following parameters:
+
+-   **`const char* filename`**: Path to the input matrix file.
+-   **`bool expl_val_for_bin_mtx = false`** (optional): When set to `true`, this forces the allocation of the `val` array. This is useful for pattern-only matrices where you intend to populate the values yourself. For matrices that already contain values, this parameter has no effect as the value array is allocated by default.
+-   **`Matrix_Metadata* meta = NULL`** (optional): A pointer to a `Matrix_Metadata` struct. If provided, the function will populate it with information from the matrix file's header.
 
 Explicit template instantiation is currently available for types:
 
@@ -55,6 +78,30 @@ Explicit template instantiation is currently available for types:
 | uint64_t   | double     |
 
 > If you need other, add the declaration at the end of `mmio.cpp`. 
+
+### Non-distributed Matrix Market File CSR Read (C wrapper)
+
+```c
+#include "mmio_c_wrapper.h"
+
+// ...
+mmio_csr_u32_f32_t *csr_matrix = mmio_read_csr_u32_f32("path/to/mtx_file", false);
+mmio_coo_u64_f64_t *coo_matrix = mmio_read_coo_u64_f64("path/to/mtx_file", false);
+```
+
+The C wrapper functions (`mmio_read_*`) take the following arguments:
+
+-   **`const char* filename`**: Path to the input matrix file.
+-   **`bool alloc_val`**: When set to `true`, this forces the allocation of the `val` array. This is useful for pattern-only matrices where you intend to populate the values yourself. For matrices that already contain values, this parameter has no effect as the value array is allocated by default.
+
+The C wrapper uses a consistent naming scheme for its types and functions:
+-   **Structs**: `mmio_<format>_<index_type>_<value_type>_t`
+-   **Functions**: `mmio_read_<format>_<index_type>_<value_type>` and `mmio_destroy_<format>_<index_type>_<value_type>`
+
+Where:
+-   `<format>` is `csr` or `coo`.
+-   `<index_type>` is `u32` or `u64`.
+-   `<value_type>` is `f32` (float) or `f64` (double).
 
 # Binary Matrix Market (.bmtx)
 

--- a/include/mmio_c_wrapper.h
+++ b/include/mmio_c_wrapper.h
@@ -1,0 +1,134 @@
+#ifndef MMIO_C_WRAPPER_H
+#define MMIO_C_WRAPPER_H
+
+#include <stdbool.h>
+#include <stdint.h> // For uint32_t, uint64_t
+#include <stddef.h> // For size_t
+
+// This guard allows the header to be included by C++ source files
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * ============================================================================
+ * C-style structs mirroring the C++ CSR_local and COO_local templates.
+ * One struct is defined for each supported (IndexType, ValueType) combination.
+ * ============================================================================
+ */
+
+// --- Combination: uint32_t index, float value ---
+typedef struct {
+    uint32_t nrows;
+    uint32_t ncols;
+    uint32_t nnz;
+    uint32_t* row_ptr;
+    uint32_t* col_idx;
+    float*    val;
+} mmio_csr_u32_f32_t;
+
+typedef struct {
+    uint32_t nrows;
+    uint32_t ncols;
+    uint32_t nnz;
+    uint32_t* row;
+    uint32_t* col;
+    float*    val;
+} mmio_coo_u32_f32_t;
+
+// --- Combination: uint32_t index, double value ---
+typedef struct {
+    uint32_t nrows;
+    uint32_t ncols;
+    uint32_t nnz;
+    uint32_t* row_ptr;
+    uint32_t* col_idx;
+    double*   val;
+} mmio_csr_u32_f64_t;
+
+typedef struct {
+    uint32_t nrows;
+    uint32_t ncols;
+    uint32_t nnz;
+    uint32_t* row;
+    uint32_t* col;
+    double*   val;
+} mmio_coo_u32_f64_t;
+
+// --- Combination: uint64_t index, float value ---
+typedef struct {
+    uint64_t nrows;
+    uint64_t ncols;
+    uint64_t nnz;
+    uint64_t* row_ptr;
+    uint64_t* col_idx;
+    float*    val;
+} mmio_csr_u64_f32_t;
+
+typedef struct {
+    uint64_t nrows;
+    uint64_t ncols;
+    uint64_t nnz;
+    uint64_t* row;
+    uint64_t* col;
+    float*    val;
+} mmio_coo_u64_f32_t;
+
+// --- Combination: uint64_t index, double value ---
+typedef struct {
+    uint64_t nrows;
+    uint64_t ncols;
+    uint64_t nnz;
+    uint64_t* row_ptr;
+    uint64_t* col_idx;
+    double*   val;
+} mmio_csr_u64_f64_t;
+
+typedef struct {
+    uint64_t nrows;
+    uint64_t ncols;
+    uint64_t nnz;
+    uint64_t* row;
+    uint64_t* col;
+    double*   val;
+} mmio_coo_u64_f64_t;
+
+
+/*
+ * ============================================================================
+ * C-friendly function wrappers.
+ * A function is provided for each data format and type combination.
+ * The naming convention is: mmio_read/destroy_<format>_<index_type>_<value_type>
+ * ============================================================================
+ */
+
+// --- uint32_t / float ---
+mmio_csr_u32_f32_t* mmio_read_csr_u32_f32(const char* filename, bool alloc_val);
+mmio_coo_u32_f32_t* mmio_read_coo_u32_f32(const char* filename, bool alloc_val);
+void mmio_destroy_csr_u32_f32(mmio_csr_u32_f32_t* matrix);
+void mmio_destroy_coo_u32_f32(mmio_coo_u32_f32_t* matrix);
+
+// --- uint32_t / double ---
+mmio_csr_u32_f64_t* mmio_read_csr_u32_f64(const char* filename, bool alloc_val);
+mmio_coo_u32_f64_t* mmio_read_coo_u32_f64(const char* filename, bool alloc_val);
+void mmio_destroy_csr_u32_f64(mmio_csr_u32_f64_t* matrix);
+void mmio_destroy_coo_u32_f64(mmio_coo_u32_f64_t* matrix);
+
+// --- uint64_t / float ---
+mmio_csr_u64_f32_t* mmio_read_csr_u64_f32(const char* filename, bool alloc_val);
+mmio_coo_u64_f32_t* mmio_read_coo_u64_f32(const char* filename, bool alloc_val);
+void mmio_destroy_csr_u64_f32(mmio_csr_u64_f32_t* matrix);
+void mmio_destroy_coo_u64_f32(mmio_coo_u64_f32_t* matrix);
+
+// --- uint64_t / double ---
+mmio_csr_u64_f64_t* mmio_read_csr_u64_f64(const char* filename, bool alloc_val);
+mmio_coo_u64_f64_t* mmio_read_coo_u64_f64(const char* filename, bool alloc_val);
+void mmio_destroy_csr_u64_f64(mmio_csr_u64_f64_t* matrix);
+void mmio_destroy_coo_u64_f64(mmio_coo_u64_f64_t* matrix);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MMIO_C_WRAPPER_H

--- a/src/mmio_c_wrapper.cpp
+++ b/src/mmio_c_wrapper.cpp
@@ -1,0 +1,114 @@
+#include "mmio.h"           // Original C++ library header
+#include "mmio_c_wrapper.h" // Our new C API header
+
+// The entire file provides C-linkage, so we wrap it in extern "C".
+extern "C" {
+
+/*
+ * ============================================================================
+ * Implementations for uint32_t / float
+ * ============================================================================
+ */
+mmio_csr_u32_f32_t* mmio_read_csr_u32_f32(const char* filename, bool alloc_val) {
+    // Call the original C++ templated function
+    CSR_local<uint32_t, float>* cpp_csr = Distr_MMIO_CSR_local_read<uint32_t, float>(filename, alloc_val, NULL);
+    // Cast the result to the C-style struct pointer. This is safe because layouts match.
+    return reinterpret_cast<mmio_csr_u32_f32_t*>(cpp_csr);
+}
+
+mmio_coo_u32_f32_t* mmio_read_coo_u32_f32(const char* filename, bool alloc_val) {
+    COO_local<uint32_t, float>* cpp_coo = Distr_MMIO_COO_local_read<uint32_t, float>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_coo_u32_f32_t*>(cpp_coo);
+}
+
+void mmio_destroy_csr_u32_f32(mmio_csr_u32_f32_t* matrix) {
+    // Cast the C-style pointer back to the C++ type
+    CSR_local<uint32_t, float>* cpp_csr = reinterpret_cast<CSR_local<uint32_t, float>*>(matrix);
+    // Call the C++ destroy function, which expects a pointer-to-pointer
+    Distr_MMIO_CSR_local_destroy(&cpp_csr);
+}
+
+void mmio_destroy_coo_u32_f32(mmio_coo_u32_f32_t* matrix) {
+    COO_local<uint32_t, float>* cpp_coo = reinterpret_cast<COO_local<uint32_t, float>*>(matrix);
+    Distr_MMIO_COO_local_destroy(&cpp_coo);
+}
+
+
+/*
+ * ============================================================================
+ * Implementations for uint32_t / double
+ * ============================================================================
+ */
+mmio_csr_u32_f64_t* mmio_read_csr_u32_f64(const char* filename, bool alloc_val) {
+    CSR_local<uint32_t, double>* cpp_csr = Distr_MMIO_CSR_local_read<uint32_t, double>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_csr_u32_f64_t*>(cpp_csr);
+}
+
+mmio_coo_u32_f64_t* mmio_read_coo_u32_f64(const char* filename, bool alloc_val) {
+    COO_local<uint32_t, double>* cpp_coo = Distr_MMIO_COO_local_read<uint32_t, double>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_coo_u32_f64_t*>(cpp_coo);
+}
+
+void mmio_destroy_csr_u32_f64(mmio_csr_u32_f64_t* matrix) {
+    CSR_local<uint32_t, double>* cpp_csr = reinterpret_cast<CSR_local<uint32_t, double>*>(matrix);
+    Distr_MMIO_CSR_local_destroy(&cpp_csr);
+}
+
+void mmio_destroy_coo_u32_f64(mmio_coo_u32_f64_t* matrix) {
+    COO_local<uint32_t, double>* cpp_coo = reinterpret_cast<COO_local<uint32_t, double>*>(matrix);
+    Distr_MMIO_COO_local_destroy(&cpp_coo);
+}
+
+
+/*
+ * ============================================================================
+ * Implementations for uint64_t / float
+ * ============================================================================
+ */
+mmio_csr_u64_f32_t* mmio_read_csr_u64_f32(const char* filename, bool alloc_val) {
+    CSR_local<uint64_t, float>* cpp_csr = Distr_MMIO_CSR_local_read<uint64_t, float>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_csr_u64_f32_t*>(cpp_csr);
+}
+
+mmio_coo_u64_f32_t* mmio_read_coo_u64_f32(const char* filename, bool alloc_val) {
+    COO_local<uint64_t, float>* cpp_coo = Distr_MMIO_COO_local_read<uint64_t, float>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_coo_u64_f32_t*>(cpp_coo);
+}
+
+void mmio_destroy_csr_u64_f32(mmio_csr_u64_f32_t* matrix) {
+    CSR_local<uint64_t, float>* cpp_csr = reinterpret_cast<CSR_local<uint64_t, float>*>(matrix);
+    Distr_MMIO_CSR_local_destroy(&cpp_csr);
+}
+
+void mmio_destroy_coo_u64_f32(mmio_coo_u64_f32_t* matrix) {
+    COO_local<uint64_t, float>* cpp_coo = reinterpret_cast<COO_local<uint64_t, float>*>(matrix);
+    Distr_MMIO_COO_local_destroy(&cpp_coo);
+}
+
+
+/*
+ * ============================================================================
+ * Implementations for uint64_t / double
+ * ============================================================================
+ */
+mmio_csr_u64_f64_t* mmio_read_csr_u64_f64(const char* filename, bool alloc_val) {
+    CSR_local<uint64_t, double>* cpp_csr = Distr_MMIO_CSR_local_read<uint64_t, double>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_csr_u64_f64_t*>(cpp_csr);
+}
+
+mmio_coo_u64_f64_t* mmio_read_coo_u64_f64(const char* filename, bool alloc_val) {
+    COO_local<uint64_t, double>* cpp_coo = Distr_MMIO_COO_local_read<uint64_t, double>(filename, alloc_val, NULL);
+    return reinterpret_cast<mmio_coo_u64_f64_t*>(cpp_coo);
+}
+
+void mmio_destroy_csr_u64_f64(mmio_csr_u64_f64_t* matrix) {
+    CSR_local<uint64_t, double>* cpp_csr = reinterpret_cast<CSR_local<uint64_t, double>*>(matrix);
+    Distr_MMIO_CSR_local_destroy(&cpp_csr);
+}
+
+void mmio_destroy_coo_u64_f64(mmio_coo_u64_f64_t* matrix) {
+    COO_local<uint64_t, double>* cpp_coo = reinterpret_cast<COO_local<uint64_t, double>*>(matrix);
+    Distr_MMIO_COO_local_destroy(&cpp_coo);
+}
+
+} // extern "C"


### PR DESCRIPTION
This pull request adds a simple C wrapper around the read functions  (`mmio_read_*`) provided by the library.

#### Parameters of the `mmio_read_*` functions
The C wrapper functions (`mmio_read_*`) take the following arguments:

-   **`const char* filename`**: Path to the input matrix file.
-   **`bool alloc_val`**: When set to `true`, this forces the allocation of the `val` array. This is useful for pattern-only matrices where you intend to populate the values yourself. For matrices that already contain values, this parameter has no effect as the value array is allocated by default.

#### Naming convention
The C wrapper uses a consistent naming scheme for its types and functions:
-   **Structs**: `mmio_<format>_<index_type>_<value_type>_t`
-   **Functions**: `mmio_read_<format>_<index_type>_<value_type>` and `mmio_destroy_<format>_<index_type>_<value_type>`

Where:
-   `<format>` is `csr` or `coo`.
-   `<index_type>` is `u32` or `u64`.
-   `<value_type>` is `f32` (float) or `f64` (double).